### PR TITLE
Revert "Revert "Revert "chore(deps): update eclipse-temurin docker tag to v26"""

### DIFF
--- a/connectors/aue-brytecube-prod/Dockerfile
+++ b/connectors/aue-brytecube-prod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:26-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt/workdir
 
 # Install Kerberos client libraries

--- a/connectors/bvd-stadtgaertnerei-p2stg/Dockerfile
+++ b/connectors/bvd-stadtgaertnerei-p2stg/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:26-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt/workdir
 
 # Label to automatically link the package to the dataspot repository in GHCR

--- a/connectors/ed-escada2/Dockerfile
+++ b/connectors/ed-escada2/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:26-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt/workdir
 
 # Label to automatically link the package to the dataspot repository in GHCR

--- a/connectors/stata-ad-test/Dockerfile
+++ b/connectors/stata-ad-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:26-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt/workdir
 
 # Install Kerberos client libraries

--- a/connectors/stata-dwh/Dockerfile
+++ b/connectors/stata-dwh/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:26-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt/workdir
 
 # Label to automatically link the package to the dataspot repository in GHCR

--- a/connectors/stata-personen-dwh-test/Dockerfile
+++ b/connectors/stata-personen-dwh-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:26-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt/workdir
 
 # Label to automatically link the package to the dataspot repository in GHCR

--- a/connectors/stata-test/Dockerfile
+++ b/connectors/stata-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:26-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt/workdir
 
 # Label to automatically link the package to the dataspot repository in GHCR


### PR DESCRIPTION
Reverts DCC-BS/dataspot#39

I.e. revert back to eclipse-temurin:21-jre-alpine

eclipse-temurin:26-jre-alpine does not have longterm support, and produces the following deprecated warning in the logs:

WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::allocateMemory has been called by io.netty.util.internal.PlatformDependent0$2 (jar:nested:/opt/executable/dataspot-connector-2026.2.2.jar/!BOOT-INF/lib/netty-common-4.1.135.Final.jar!/)
WARNING: Please consider reporting this to the maintainers of class io.netty.util.internal.PlatformDependent0$2
WARNING: sun.misc.Unsafe::allocateMemory will be removed in a future release

We'll stay on eclipse-temurin:21-jre-alpine for now.